### PR TITLE
fix: correct minimum brightness for Litra Beam devices

### DIFF
--- a/dist/commonjs/driver.js
+++ b/dist/commonjs/driver.js
@@ -19,7 +19,7 @@ const PRODUCT_IDS = [
 const USAGE_PAGE = 0xff43;
 const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
     [DeviceType.LitraGlow]: 20,
-    [DeviceType.LitraBeam]: 20,
+    [DeviceType.LitraBeam]: 30,
 };
 const MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
     [DeviceType.LitraGlow]: 250,

--- a/dist/esm/driver.js
+++ b/dist/esm/driver.js
@@ -13,7 +13,7 @@ const PRODUCT_IDS = [
 const USAGE_PAGE = 0xff43;
 const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
     [DeviceType.LitraGlow]: 20,
-    [DeviceType.LitraBeam]: 20,
+    [DeviceType.LitraBeam]: 30,
 };
 const MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
     [DeviceType.LitraGlow]: 250,

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -16,7 +16,7 @@ const USAGE_PAGE = 0xff43;
 
 const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
   [DeviceType.LitraGlow]: 20,
-  [DeviceType.LitraBeam]: 20,
+  [DeviceType.LitraBeam]: 30,
 };
 
 const MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {

--- a/tests/driver.test.ts
+++ b/tests/driver.test.ts
@@ -159,7 +159,7 @@ describe('setBrightnessInLumen', () => {
     const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
 
     expect(() => setBrightnessInLumen(fakeLitraBeam, 19)).toThrowError(
-      'Provided brightness must be between 20 and 400',
+      'Provided brightness must be between 30 and 400',
     );
   });
 
@@ -173,7 +173,7 @@ describe('setBrightnessInLumen', () => {
     const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
 
     expect(() => setBrightnessInLumen(fakeLitraBeam, 401)).toThrowError(
-      'Provided brightness must be between 20 and 400',
+      'Provided brightness must be between 30 and 400',
     );
   });
 
@@ -219,7 +219,7 @@ describe('setBrightnessPercentage', () => {
     setBrightnessPercentage(fakeLitraBeam, 0);
 
     expect(fakeLitraBeam.hid.write).toBeCalledWith([
-      17, 255, 4, 76, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      17, 255, 4, 76, 0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 
@@ -248,7 +248,7 @@ describe('getMinimumBrightnessInLumenForDevice', () => {
 
   it('returns the correct minimum brightness for a Litra Beam', () => {
     const fakeDevice = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
-    expect(getMinimumBrightnessInLumenForDevice(fakeDevice)).toEqual(20);
+    expect(getMinimumBrightnessInLumenForDevice(fakeDevice)).toEqual(30);
   });
 });
 


### PR DESCRIPTION
This library validates that brightness values (provided in Lumens) are within the device's supported range. 

When adding support for the Litra Beam, I assumed that it would have the same minimum brightness as the Litra Glow (30 Lumens), but it turns out that the minimum is 30. This fixes the validations.