### PR TITLE
feat: add new `litra-devices` CLI tool for listing all connected devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ With the package installed:
 * Use the `litra-brightness-lm` command to set your Litra's brightness to a value in Lumen (e.g. `litra-brightness 250`).
 * Use the `litra-temperature` command to set your Litra's temperature to a percentage of its maximum (e.g. `litra-temperature 75`).
 * Use the `litra-temperature-k` command to set your Litra's temperature to a value in Kelvin (e.g. `litra-temperature-k 6500`).
-* Use the `litra-identify` command to interactively identify the serial numbers of your Litra devices, if you have multiple connected.
 
-All of the above commands can be run with `--help` for more detailed documentation. 
+All of the these commands support a `--serial-number`/`-s` argument to specify the serial number of the device you want to target. If you only have one Litra device, you can omit this argument. If you have multiple devices, we recommend specifying it. If it isn't specified, the "first" device will be picked, but this isn't guaranteed to be stable between command runs.
 
-All of the commands except `litra-identify` support a `--serial-number`/`-s` argument to specify the serial number of the device you want to target. If you only have one Litra device, you can omit this argument. If you have multiple devices, we recommend specifying it. If it isn't specified, the "first" device will be picked, but this isn't guaranteed to be stable between command runs.
+You can also use:
+
+* `litra-devices` to list Litra devices connected to your machine, including in JSON format with `--json`
+* `litra-identify` to interactively identify the serial numbers of your Litra devices, if you have multiple connected
+
+Each CLI command can also be called with `--help` for more detailed documentation.
 
 ## Using as a JavaScript library
 

--- a/dist/commonjs/cli/litra-devices.d.ts
+++ b/dist/commonjs/cli/litra-devices.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/dist/commonjs/cli/litra-devices.js
+++ b/dist/commonjs/cli/litra-devices.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const commander_1 = require("commander");
+const driver_1 = require("../driver");
+commander_1.program
+    .name('litra-devices')
+    .description('Lists Litra devices connected to your computer')
+    .option('--json', 'output the list of devices in structured JSON format');
+commander_1.program.parse();
+const { json } = commander_1.program.opts();
+const devices = (0, driver_1.findDevices)();
+if (json) {
+    console.log(JSON.stringify(devices.map((device) => ({
+        name: (0, driver_1.getNameForDevice)(device),
+        serial_number: device.serialNumber,
+    }))));
+}
+else {
+    if (devices.length) {
+        for (const device of devices) {
+            console.log(`- ${(0, driver_1.getNameForDevice)(device)} (${device.serialNumber})`);
+        }
+    }
+    else {
+        console.log('No devices found');
+    }
+}
+process.exit(0);

--- a/dist/esm/cli/litra-devices.d.ts
+++ b/dist/esm/cli/litra-devices.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/dist/esm/cli/litra-devices.js
+++ b/dist/esm/cli/litra-devices.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { program } from 'commander';
+import { findDevices, getNameForDevice } from '../driver';
+program
+    .name('litra-devices')
+    .description('Lists Litra devices connected to your computer')
+    .option('--json', 'output the list of devices in structured JSON format');
+program.parse();
+const { json } = program.opts();
+const devices = findDevices();
+if (json) {
+    console.log(JSON.stringify(devices.map((device) => ({
+        name: getNameForDevice(device),
+        serial_number: device.serialNumber,
+    }))));
+}
+else {
+    if (devices.length) {
+        for (const device of devices) {
+            console.log(`- ${getNameForDevice(device)} (${device.serialNumber})`);
+        }
+    }
+    else {
+        console.log('No devices found');
+    }
+}
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "litra-brightness-lm": "./dist/commonjs/cli/litra-brightness-lm.js",
     "litra-temperature": "./dist/commonjs/cli/litra-temperature-lm.js",
     "litra-temperature-k": "./dist/commonjs/cli/litra-temperature-k.js",
-    "litra-identify": "./dist/commonjs/cli/litra-identify.js"
+    "litra-identify": "./dist/commonjs/cli/litra-identify.js",
+    "litra-devices": "./dist/commonjs/cli/litra-devices.js"
   }
 }

--- a/src/cli/litra-devices.ts
+++ b/src/cli/litra-devices.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { program } from 'commander';
+import { findDevices, getNameForDevice } from '../driver';
+
+program
+  .name('litra-devices')
+  .description(
+    'Lists Litra devices connected to your computer. Defaults to human-readable plain text.',
+  )
+  .option('--json', 'output the list of devices in structured JSON format');
+
+program.parse();
+const { json } = program.opts();
+
+const devices = findDevices();
+
+if (json) {
+  console.log(
+    JSON.stringify(
+      devices.map((device) => ({
+        name: getNameForDevice(device),
+        serial_number: device.serialNumber,
+      })),
+    ),
+  );
+} else {
+  if (devices.length) {
+    for (const device of devices) {
+      console.log(`- ${getNameForDevice(device)} (${device.serialNumber})`);
+    }
+  } else {
+    console.log('No devices found');
+  }
+}
+
+process.exit(0);


### PR DESCRIPTION
This adds a new `litra-devices` CLI tool which allows you to list all connected devices, e.g.:

```sh
$ litra-devices
- Logitech Litra Glow (2214FE100WN8)
```

By default, it outputs a list of devices in plain text to stdout. By specifying the `--json` option, you can instead output JSON to stdout:

```sh
$ litra-devices --json
[{"name":"Logitech Litra Glow","serial_number":"2214FE100WN8"}]
```

I'm using the JSON feature to power a new [Raycast extension](https://github.com/timrogers/raycast-logitech-litra). (Although Raycast extensions can use npm packages, they can't deal with the native extensions from `node-hid`, so the extension will ask you to install this package separately.)