### PR TITLE
fix: allow setting Litra Beam devices' brightness to values over 255 Lumens

### DIFF
--- a/dist/commonjs/driver.js
+++ b/dist/commonjs/driver.js
@@ -177,7 +177,7 @@ const setBrightnessInLumen = (device, brightnessInLumen) => {
     if (brightnessInLumen < minimumBrightness || brightnessInLumen > maximumBrightness) {
         throw `Provided brightness must be between ${minimumBrightness} and ${maximumBrightness} for this device`;
     }
-    device.hid.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
+    device.hid.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x4c, ...(0, utils_1.integerToBytes)(brightnessInLumen)], 20, 0x00));
 };
 exports.setBrightnessInLumen = setBrightnessInLumen;
 /**

--- a/dist/esm/driver.js
+++ b/dist/esm/driver.js
@@ -163,7 +163,7 @@ export const setBrightnessInLumen = (device, brightnessInLumen) => {
     if (brightnessInLumen < minimumBrightness || brightnessInLumen > maximumBrightness) {
         throw `Provided brightness must be between ${minimumBrightness} and ${maximumBrightness} for this device`;
     }
-    device.hid.write(padRight([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
+    device.hid.write(padRight([0x11, 0xff, 0x04, 0x4c, ...integerToBytes(brightnessInLumen)], 20, 0x00));
 };
 /**
  * Gets the current brightness of your Logitech Litra device, measured in Lumen

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -212,7 +212,9 @@ export const setBrightnessInLumen = (device: Device, brightnessInLumen: number):
     throw `Provided brightness must be between ${minimumBrightness} and ${maximumBrightness} for this device`;
   }
 
-  device.hid.write(padRight([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
+  device.hid.write(
+    padRight([0x11, 0xff, 0x04, 0x4c, ...integerToBytes(brightnessInLumen)], 20, 0x00),
+  );
 };
 
 /**

--- a/tests/driver.test.ts
+++ b/tests/driver.test.ts
@@ -241,7 +241,7 @@ describe('setBrightnessPercentage', () => {
     setBrightnessPercentage(fakeLitraBeam, 100);
 
     expect(fakeLitraBeam.hid.write).toBeCalledWith([
-      17, 255, 4, 76, 0, 400, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      17, 255, 4, 76, 1, 144, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 


### PR DESCRIPTION
Fixes #132.