### PR TITLE
fix: update the package description and readme to document that only Litra devices connected via USB - not Bluetooth - are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With this driver, you can:
 This library:
 
 * only works with Litra devices connected via USB. Logitech Litra Beam devices connected via Bluetooth are not supported.
-* is only tested on macOS Monterey (12.5) and Windows 11. It's powered by [`node-hid`](https://github.com/node-hid/node-hid), which is compatible with other macOS versions, Windows and Linux, so it would be expected to work there too, but your milage may vary 🙏
+* is only tested on macOS Monterey (12.5) and Windows 11. It's powered by [`node-hid`](https://github.com/node-hid/node-hid), which is compatible with other macOS versions, Windows and Linux, so it would be expected to work there too, but your mileage may vary 🙏
 
 ## Using as a command line tool
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logitech Litra
 
-This JavaScript driver allows you to control [Logitech Litra Glow](https://www.logitech.com/en-gb/products/lighting/litra-glow.946-000002.html) and [Logitech Litra Beam](https://www.logitech.com/en-gb/products/lighting/litra-beam.946-000007.html) lights using a CLI and from your JavaScript code.
+This JavaScript driver allows you to control USB-connected [Logitech Litra Glow](https://www.logitech.com/en-gb/products/lighting/litra-glow.946-000002.html) and [Logitech Litra Beam](https://www.logitech.com/en-gb/products/lighting/litra-beam.946-000007.html) lights using a CLI and from your JavaScript code.
 
 With this driver, you can:
 
@@ -11,7 +11,10 @@ With this driver, you can:
 
 ## Compatibility
 
-This library is only tested on macOS Monterey (12.5) and Windows 11. It's powered by [`node-hid`](https://github.com/node-hid/node-hid), which is compatible with other macOS versions, Windows and Linux, so it would be expected to work there too, but your milage may vary 🙏
+This library:
+
+* only works with Litra devices connected via USB. Logitech Litra Beam devices connected via Bluetooth are not supported.
+* is only tested on macOS Monterey (12.5) and Windows 11. It's powered by [`node-hid`](https://github.com/node-hid/node-hid), which is compatible with other macOS versions, Windows and Linux, so it would be expected to work there too, but your milage may vary 🙏
 
 ## Using as a command line tool
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "litra",
   "version": "0.0.0-development",
-  "description": "A driver for controlling Logitech Litra devices, including the Logitech Litra Glow and Logitech Litra Beam, from a CLI or your JavaScript code",
+  "description": "A driver for controlling Logitech Litra devices connected via USB, including the Logitech Litra Glow and Logitech Litra Beam, from a CLI or your JavaScript code",
   "main": "./dist/commonjs/driver.js",
   "module": "./dist/esm/driver.js",
   "homepage": "https://github.com/timrogers/litra",


### PR DESCRIPTION
This updates the readme and package description to document that only Litra devices connected via USB - not Bluetooth - are supported.

Thanks to @RafaelDavisH for the [feedback](https://github.com/raycast/extensions/issues/6620.) in the context of [`timrogers/raycast-logitech-litra`](https://github.com/timrogers/raycast-logitech-litra).