### PR TITLE
fix: add support for Litra Beam devices with alternative USD product ID

### DIFF
--- a/dist/commonjs/driver.js
+++ b/dist/commonjs/driver.js
@@ -10,11 +10,12 @@ var DeviceType;
 (function (DeviceType) {
     DeviceType["LitraGlow"] = "litra_glow";
     DeviceType["LitraBeam"] = "litra_beam";
-})(DeviceType = exports.DeviceType || (exports.DeviceType = {}));
+})(DeviceType || (exports.DeviceType = DeviceType = {}));
 const VENDOR_ID = 0x046d;
 const PRODUCT_IDS = [
     0xc900,
-    0xc901, // Litra Beam
+    0xc901,
+    0xb901, // Litra Beam
 ];
 const USAGE_PAGE = 0xff43;
 const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
@@ -218,9 +219,10 @@ exports.setBrightnessPercentage = setBrightnessPercentage;
  */
 const getDeviceTypeByProductId = (productId) => {
     switch (productId) {
-        case 0xc900:
+        case PRODUCT_IDS[0]:
             return DeviceType.LitraGlow;
-        case 0xc901:
+        case PRODUCT_IDS[1]:
+        case PRODUCT_IDS[2]:
             return DeviceType.LitraBeam;
         default:
             throw 'Unknown device type';

--- a/dist/esm/driver.js
+++ b/dist/esm/driver.js
@@ -8,7 +8,8 @@ export var DeviceType;
 const VENDOR_ID = 0x046d;
 const PRODUCT_IDS = [
     0xc900,
-    0xc901, // Litra Beam
+    0xc901,
+    0xb901, // Litra Beam
 ];
 const USAGE_PAGE = 0xff43;
 const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
@@ -201,9 +202,10 @@ export const setBrightnessPercentage = (device, brightnessPercentage) => {
  */
 const getDeviceTypeByProductId = (productId) => {
     switch (productId) {
-        case 0xc900:
+        case PRODUCT_IDS[0]:
             return DeviceType.LitraGlow;
-        case 0xc901:
+        case PRODUCT_IDS[1]:
+        case PRODUCT_IDS[2]:
             return DeviceType.LitraBeam;
         default:
             throw 'Unknown device type';

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -16,6 +16,7 @@ const VENDOR_ID = 0x046d;
 const PRODUCT_IDS = [
   0xc900, // Litra Glow
   0xc901, // Litra Beam
+  0xb901, // Litra Beam
 ];
 const USAGE_PAGE = 0xff43;
 
@@ -265,9 +266,10 @@ export const setBrightnessPercentage = (
  */
 const getDeviceTypeByProductId = (productId: number): DeviceType => {
   switch (productId) {
-    case 0xc900:
+    case PRODUCT_IDS[0]:
       return DeviceType.LitraGlow;
-    case 0xc901:
+    case PRODUCT_IDS[1]:
+    case PRODUCT_IDS[2]:
       return DeviceType.LitraBeam;
     default:
       throw 'Unknown device type';


### PR DESCRIPTION
I just added my litra beam product ID. I don't know why I have a different one 🤷 

![image](https://github.com/timrogers/litra/assets/11815139/48cf6c9d-6eed-460b-9d32-631e9413e413)
